### PR TITLE
Allow .ico (favicons) as image type for icons

### DIFF
--- a/src/SmartIcon/index.js
+++ b/src/SmartIcon/index.js
@@ -9,7 +9,7 @@ import { memoize } from 'cerebro-tools'
  * @param  {String} path
  * @return {Boolean}
  */
-const isImage = (path) => !!path.match(/(^data:)|(\.(png|jpe?g|svg)$)/)
+const isImage = (path) => !!path.match(/(^data:)|(\.(png|jpe?g|svg|ico)$)/)
 
 /**
  * This component renders:


### PR DESCRIPTION
Electron (any modern browser, really) is be able to display these within an image tag.