### PR TITLE
fix: broken components due to backwards compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cerebroapp/cerebro-ui",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "Package with common UI components for Cerebro plugins",
   "main": "dist/index.js",
   "repository": "cerebroapp/cerebro-ui",

--- a/src/KeyboardNav/index.js
+++ b/src/KeyboardNav/index.js
@@ -71,18 +71,17 @@ const onKeyDown = (wrapper, event) => {
   }
 }
 
-const KeyboardNav = ({ children }) => {
-  const ref = useRef(null)
-
-  const handleKeyDown = (event) => {
-    onKeyDown(ref, event)
+class KeyboardNav extends React.Component {
+  onKeyDown(event) {
+    onKeyDown(this.wrapper, event)
   }
-
-  return (
-    <div ref={ref} onKeyDown={handleKeyDown}>
-      {children}
-    </div>
-  )
+  render() {
+    return (
+      <div onKeyDown={this.onKeyDown.bind(this)} ref={(el) => { this.wrapper = el }}>
+        {this.props.children}
+      </div>
+    )
+  }
 }
 
 KeyboardNav.propTypes = {

--- a/src/Preload.js
+++ b/src/Preload.js
@@ -1,26 +1,34 @@
-import { useEffect } from 'react'
+import { Component } from 'react'
 import PropTypes from 'prop-types'
 
 /**
  * Component that renders child function only after props.promise is resolved or rejected
  * You can provide props.loader that will be rendered before
- */
+  @deprecated
+*/
 
-const Preload = ({ loader, children, promise }) => {
-  const [result, setResult] = useState(null)
-  const [error, setError] = useState(null)
-
-  useEffect(() => {
-    promise
-      .then(result => setResult(result))
-      .catch(error => setError(error))
-  },[promise])
-
-  if (result || error) {
-    return children(result, error)
+class Preload extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      result: null,
+      error: null
+    }
   }
-
-  return loader || null
+  componentDidMount() {
+    console.warn("This component has been deprecated. Please use the new useState hook instead.")
+    this.props.promise
+      .then(result => this.setState({ result }))
+      .catch(error => this.setState({ error }))
+  }
+  render() {
+    const { loader, children } = this.props
+    const { result, error } = this.state
+    if (result || error) {
+      return children(result, error)
+    }
+    return loader || null
+  }
 }
 
 Preload.propTypes = {


### PR DESCRIPTION
As some of the plugins are using this library we can not migrate for now this two components because it causes errors in cerebro. I restored them to the previous state and added a deprecation warning to `Preload`